### PR TITLE
Create retro CRT terminal interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,68 +1,137 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>HabbaHabba // CRT Vibes</title>
+  <meta charset="UTF-8" />
+  <title>CRT Terminal</title>
   <style>
+    :root {
+      color-scheme: dark;
+    }
+    * {
+      box-sizing: border-box;
+    }
     body {
       margin: 0;
-      height: 100vh;
-      background-color: #000;
-      color: #00ff00;
-      font-family: "Courier New", Courier, monospace;
+      min-height: 100vh;
+      background: radial-gradient(circle at 20% 20%, rgba(57, 255, 20, 0.15), transparent 55%),
+                  radial-gradient(circle at 80% 30%, rgba(57, 255, 20, 0.1), transparent 60%),
+                  #020202;
+      color: #39ff14;
+      font-family: "IBM Plex Mono", "Courier New", Courier, monospace;
       display: flex;
-      flex-direction: column;
       align-items: center;
       justify-content: center;
-      text-align: center;
+      padding: 3rem;
       overflow: hidden;
     }
-    h1, p {
-      text-shadow: 0 0 8px #00ff00;
-    }
-    .crt {
+    .crt-frame {
       position: relative;
+      width: min(900px, 90vw);
+      padding: 3rem;
+      border: 4px solid rgba(57, 255, 20, 0.4);
+      background: rgba(0, 0, 0, 0.85);
+      box-shadow: 0 0 30px rgba(57, 255, 20, 0.45), inset 0 0 40px rgba(57, 255, 20, 0.2);
+      text-shadow: 0 0 8px rgba(57, 255, 20, 0.6);
+      backdrop-filter: blur(1px);
     }
-    .crt::after {
+    .crt-frame::before {
       content: "";
       position: absolute;
-      top: 0; left: 0;
-      width: 100%; height: 100%;
+      inset: 0;
       background: repeating-linear-gradient(
         to bottom,
-        rgba(0, 0, 0, 0.2),
-        rgba(0, 0, 0, 0.2) 2px,
-        transparent 2px,
-        transparent 4px
+        rgba(57, 255, 20, 0.08),
+        rgba(57, 255, 20, 0.08) 2px,
+        rgba(0, 0, 0, 0) 2px,
+        rgba(0, 0, 0, 0) 4px
       );
+      mix-blend-mode: screen;
+      pointer-events: none;
+      opacity: 0.55;
+    }
+    .crt-frame::after {
+      content: "";
+      position: absolute;
+      inset: -10px;
+      border: 2px solid rgba(57, 255, 20, 0.25);
+      filter: blur(6px);
       pointer-events: none;
     }
-    img {
-      width: 200px;
-      margin-top: 20px;
-      filter: drop-shadow(0 0 10px #00ff00);
+    h1 {
+      margin: 0 0 1.5rem;
+      font-size: clamp(1.8rem, 5vw, 3.2rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
-    button {
-      background: black;
-      border: 2px solid #00ff00;
-      color: #00ff00;
-      font-family: inherit;
-      font-size: 1em;
-      padding: 10px 20px;
-      margin-top: 30px;
-      cursor: pointer;
-      text-shadow: 0 0 5px #00ff00;
+    p {
+      margin: 0 0 1.2rem;
+      line-height: 1.6;
+      font-size: clamp(1rem, 2.2vw, 1.3rem);
     }
-    button:hover {
-      background: #00ff00;
-      color: black;
+    .screen {
+      position: relative;
+    }
+    .line {
+      display: block;
+      white-space: pre-wrap;
+      margin-bottom: 0.65rem;
+      animation: textGlow 4s ease-in-out infinite;
+    }
+    .line:nth-child(odd) {
+      animation-delay: 1s;
+    }
+    .line:nth-child(even) {
+      animation-delay: 2s;
+    }
+    .cursor {
+      display: inline-block;
+      width: 0.6em;
+      margin-left: 0.2em;
+      background: rgba(57, 255, 20, 0.85);
+      box-shadow: 0 0 10px rgba(57, 255, 20, 0.9);
+      animation: cursorBlink 0.75s steps(1) infinite;
+    }
+    .glare {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(255, 255, 255, 0.08), transparent 30%, transparent 70%, rgba(255, 255, 255, 0.06));
+      mix-blend-mode: screen;
+      opacity: 0.6;
+      pointer-events: none;
+    }
+    @keyframes cursorBlink {
+      0%, 49% { opacity: 1; }
+      50%, 100% { opacity: 0; }
+    }
+    @keyframes textGlow {
+      0%, 100% {
+        text-shadow: 0 0 6px rgba(57, 255, 20, 0.65), 0 0 16px rgba(57, 255, 20, 0.3);
+      }
+      50% {
+        text-shadow: 0 0 10px rgba(57, 255, 20, 0.9), 0 0 24px rgba(57, 255, 20, 0.45);
+      }
+    }
+    @keyframes screenFlicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 56%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.8; }
+      40% { opacity: 0.9; }
+      60% { opacity: 0.85; }
+    }
+    .crt-frame {
+      animation: screenFlicker 6s linear infinite;
     }
   </style>
 </head>
-<body class="crt">
-  <h1>Welcome to HabbaHabba</h1>
-  <p>Terminal green, CRT-style ✨</p>
-  <img src="your-image.png" alt="Green CRT eye logo">
-  <button>Enter</button>
+<body>
+  <div class="crt-frame">
+    <div class="glare"></div>
+    <div class="screen">
+      <h1>Atlas Mainframe Online</h1>
+      <p class="line">BOOT SEQUENCE: SYSTEMS NOMINAL</p>
+      <p class="line">AUTH MODULE: READY FOR INPUT</p>
+      <p class="line">LAST LOGIN: 1984-09-12 23:14 PST</p>
+      <p class="line">/usr/local/bin&gt;_ <span class="cursor"></span></p>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign index.html to mimic a green-on-black CRT terminal
- add scanline overlay, screen flicker, and glow effects for a retro aesthetic
- implement blinking cursor and animated text glow for terminal realism

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d855a0a54883289eaa1694d2552202